### PR TITLE
Immutable state variable detector

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 setup(
     name="slither-analyzer",
     description="Slither is a Solidity static analysis framework written in Python 3.",
-    url="https://github.com/drahrealm/slither-1",
+    url="https://github.com/redacted-cartel/slither",
     author="Trail of Bits",
     version="0.8.2",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 setup(
     name="slither-analyzer",
     description="Slither is a Solidity static analysis framework written in Python 3.",
-    url="https://github.com/crytic/slither",
+    url="https://github.com/drahrealm/slither-1",
     author="Trail of Bits",
     version="0.8.2",
     packages=find_packages(),

--- a/slither/detectors/all_detectors.py
+++ b/slither/detectors/all_detectors.py
@@ -1,5 +1,4 @@
 # pylint: disable=unused-import,relative-beyond-top-level
-from .examples.backdoor import Backdoor
 from .variables.uninitialized_state_variables import UninitializedStateVarsDetection
 from .variables.uninitialized_storage_variables import UninitializedStorageVars
 from .variables.uninitialized_local_variables import UninitializedLocalVars
@@ -81,3 +80,5 @@ from .functions.dead_code import DeadCode
 from .statements.write_after_write import WriteAfterWrite
 from .statements.msg_value_in_loop import MsgValueInLoop
 from .statements.delegatecall_in_loop import DelegatecallInLoop
+
+from .variables.possible_immutable_state_variables import ImmutableCandidateStateVars

--- a/slither/detectors/attributes/incorrect_solc.py
+++ b/slither/detectors/attributes/incorrect_solc.py
@@ -44,6 +44,7 @@ Deploy with any of the following Solidity versions:
 - 0.6.11 - 0.6.12
 - 0.7.5 - 0.7.6
 - 0.8.4 - 0.8.7
+- 0.8.12
 Use a simple pragma version that allows any of these versions.
 Consider using the latest version of Solidity for testing."""
     # endregion wiki_recommendation
@@ -69,6 +70,7 @@ Consider using the latest version of Solidity for testing."""
         "0.8.5",
         "0.8.6",
         "0.8.7",
+        "0.8.12",
     ]
 
     # Indicates the versions that should not be used.

--- a/slither/detectors/variables/possible_immutable_state_variables.py
+++ b/slither/detectors/variables/possible_immutable_state_variables.py
@@ -1,0 +1,72 @@
+"""
+Module detecting state variables that could be declared as immutable
+"""
+from slither.core.compilation_unit import SlitherCompilationUnit
+from slither.core.solidity_types.elementary_type import ElementaryType
+from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
+from slither.formatters.variables.possible_const_state_variables import custom_format
+
+
+class ImmutableCandidateStateVars(AbstractDetector):
+    """
+    State variables that could be declared as immutable detector.
+    Only value types can be declared as immutable
+    Reference: https://docs.soliditylang.org/en/latest/contracts.html#immutable
+    """
+
+    ARGUMENT = "immutable-states"
+    HELP = "State variables that could be declared immutable"
+    IMPACT = DetectorClassification.OPTIMIZATION
+    CONFIDENCE = DetectorClassification.HIGH
+
+    WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation"
+
+    WIKI_TITLE = "State variables that could be declared immutable"
+    WIKI_DESCRIPTION = "State variables should be declared immutable whenever possible to save gas."
+    WIKI_RECOMMENDATION = "Add the `immutable` attributes to state variables that never change after assigned once."
+
+    @staticmethod
+    def _valid_candidate(v):
+        return isinstance(v.type, ElementaryType) and not (v.is_constant or v.is_immutable)
+
+    @staticmethod
+    def _can_be_immutable(v):
+        return str(v.type) != "string" and str(v.type) != "bytes"
+
+    def _detect(self):
+        """Detect state variables that could be declared immutable"""
+        results = []
+
+        all_variables = [c.state_variables for c in self.compilation_unit.contracts]
+        all_variables = {item for sublist in all_variables for item in sublist}
+        all_candidates = {
+            v for v in all_variables if self._valid_candidate(v)
+        }
+
+        all_functions = [c.all_functions_called for c in self.compilation_unit.contracts]
+        all_functions = list({item for sublist in all_functions for item in sublist})
+
+        all_variables_written = [
+            f.state_variables_written for f in all_functions if f.is_constructor
+        ]
+        all_variables_written = {item for sublist in all_variables_written for item in sublist}
+
+        immutable_variables = [
+            v
+            for v in all_candidates
+            if (v in all_variables_written)
+        ]
+        # Order for deterministic results
+        immutable_variables = sorted(immutable_variables, key=lambda x: x.canonical_name)
+
+        # Create a result for each finding
+        for v in immutable_variables:
+            info = [v, " can be declared immutable\n"]
+            json = self.generate_result(info)
+            results.append(json)
+
+        return results
+
+    @staticmethod
+    def _format(compilation_unit: SlitherCompilationUnit, result):
+        custom_format(compilation_unit, result)


### PR DESCRIPTION
## Changes
- Added detector for any state variables that can be declared as immutable (included by default)
- Included `0.8.12` as supported version to omit warnings